### PR TITLE
Fix "no" displaying as "false" in syllabary

### DIFF
--- a/_pages/toki-pona/dictionaries/syllabary.md
+++ b/_pages/toki-pona/dictionaries/syllabary.md
@@ -114,7 +114,7 @@ definitions:
 - image: "/images/t47_tokipona/kalalili/t47_kalalili_ni.jpg"
   text: ni
 - image: "/images/t47_tokipona/kalalili/t47_kalalili_no.jpg"
-  text: no
+  text: "no"
 - image: "/images/t47_tokipona/kalalili/t47_kalalili_nu.jpg"
   text: nu
 - image: "/images/t47_tokipona/kalalili/t47_kalalili_nan.jpg"


### PR DESCRIPTION
Because YAML parses "no" as boolean false, the syllabary displays the label for this syllable as "false". Quoting it forces it to be parsed as the string "no" which hopefully fixes the display issue.